### PR TITLE
feat: integrate informer cache for hot resources

### DIFF
--- a/pkg/handlers/resources/handler.go
+++ b/pkg/handlers/resources/handler.go
@@ -14,6 +14,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metricsv1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type resourceHandler interface {
@@ -27,7 +28,7 @@ type resourceHandler interface {
 	Searchable() bool
 	Search(c *gin.Context, query string, limit int64) ([]common.SearchResult, error)
 
-	GetResource(c *gin.Context, namespace, name string) (interface{}, error)
+	GetResource(c *gin.Context, namespace, name string) (client.Object, error)
 
 	registerCustomRoutes(group *gin.RouterGroup)
 }

--- a/pkg/kube/store.go
+++ b/pkg/kube/store.go
@@ -1,0 +1,109 @@
+package kube
+
+import (
+	"errors"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	appsv1 "k8s.io/client-go/listers/apps/v1"
+	listerscorev1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+type Store interface {
+	PodLister() listerscorev1.PodLister
+	DeploymentLister() appsv1.DeploymentLister
+	StatefulSetLister() appsv1.StatefulSetLister
+	ServiceLister() listerscorev1.ServiceLister
+	NodeLister() listerscorev1.NodeLister
+}
+
+type store struct {
+	podLister         listerscorev1.PodLister
+	deploymentLister  appsv1.DeploymentLister
+	statefulSetLister appsv1.StatefulSetLister
+	serviceLister     listerscorev1.ServiceLister
+	nodeLister        listerscorev1.NodeLister
+}
+
+func (s *store) DeploymentLister() appsv1.DeploymentLister {
+	return s.deploymentLister
+}
+
+func (s *store) StatefulSetLister() appsv1.StatefulSetLister {
+	return s.statefulSetLister
+}
+
+func (s *store) PodLister() listerscorev1.PodLister {
+	return s.podLister
+}
+
+func (s *store) ServiceLister() listerscorev1.ServiceLister {
+	return s.serviceLister
+}
+
+func (s *store) NodeLister() listerscorev1.NodeLister {
+	return s.nodeLister
+}
+
+func Load(clientset kubernetes.Interface) (Store, error) {
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(clientset, 0)
+
+	pod := informerFactory.Core().V1().Pods()
+	podInformer := pod.Informer()
+	deployment := informerFactory.Apps().V1().Deployments()
+	deploymentInformer := deployment.Informer()
+	statefulSet := informerFactory.Apps().V1().StatefulSets()
+	statefulSetInformer := statefulSet.Informer()
+	service := informerFactory.Core().V1().Services()
+	serviceInformer := service.Informer()
+	node := informerFactory.Core().V1().Nodes()
+	nodeInformer := node.Informer()
+
+	informerFactory.Start(wait.NeverStop)
+
+	sharedInformers := []cache.SharedInformer{
+		podInformer,
+		deploymentInformer,
+		statefulSetInformer,
+		serviceInformer,
+		nodeInformer,
+	}
+	var wg sync.WaitGroup
+	errCh := make(chan error, 1)
+	wg.Add(len(sharedInformers))
+	for _, si := range sharedInformers {
+		go func(si cache.SharedInformer) {
+			defer wg.Done()
+			if !cache.WaitForCacheSync(wait.NeverStop, si.HasSynced) {
+				select {
+				case errCh <- errors.New("timed out waiting for caches to sync"):
+				default:
+				}
+			}
+		}(si)
+	}
+	wg.Wait()
+
+	select {
+	case err := <-errCh:
+		return nil, err
+	default:
+	}
+
+	podLister := pod.Lister()
+	deploymentLister := deployment.Lister()
+	statefulSetLister := statefulSet.Lister()
+	serviceLister := service.Lister()
+	nodeLister := node.Lister()
+
+	return &store{
+		podLister:         podLister,
+		deploymentLister:  deploymentLister,
+		statefulSetLister: statefulSetLister,
+		serviceLister:     serviceLister,
+		nodeLister:        nodeLister,
+	}, nil
+}


### PR DESCRIPTION
**Why is there this PR?** 
1. Pulling resources directly from the apiserver using `kubernetes.Interface` will cause access pressure on the apiserver, especially when obtaining the full amount of resource data.
2. We can easily obtain resources by using the Informer cache + real-time Watch mechanism.
3. Caching all resources will cause excessive local memory usage, so it is recommended to cache hot spot resources, e.g., Pods, Deployments.

So what do you think? If you have any questions, can we continue to communicate.