### PR TITLE
Fix: 'NodeTerminalHandler' podName length exceeding 63 characters error

### DIFF
--- a/pkg/handlers/node_terminal_handler.go
+++ b/pkg/handlers/node_terminal_handler.go
@@ -90,7 +90,11 @@ func (h *NodeTerminalHandler) createNodeAgent(ctx context.Context, cs *cluster.C
 		podName = fmt.Sprintf("%s-%s", nodeName, utils.RandomString(5))
 	}
 
-	if len(podName) >= 63 {
+	if len(podName) > 63 {
+		podName = fmt.Sprintf("%s-%s", nodeName, utils.RandomString(5))
+	}
+
+	if len(podName) > 63 {
 		podName = podName[:62]
 	}
 	// Define the kite node agent pod spec

--- a/pkg/handlers/node_terminal_handler.go
+++ b/pkg/handlers/node_terminal_handler.go
@@ -86,6 +86,13 @@ func (h *NodeTerminalHandler) HandleNodeTerminalWebSocket(c *gin.Context) {
 func (h *NodeTerminalHandler) createNodeAgent(ctx context.Context, cs *cluster.ClientSet, nodeName string) (string, error) {
 	podName := fmt.Sprintf("%s-%s-%s", common.NodeTerminalPodName, nodeName, utils.RandomString(5))
 
+	if len(podName) >= 63 {
+		podName = fmt.Sprintf("%s-%s", nodeName, utils.RandomString(5))
+	}
+
+	if len(podName) >= 63 {
+		podName = podName[:62]
+	}
 	// Define the kite node agent pod spec
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
修复 NodeTerminalHandler 中，因为pod名字过长的报错 