### PR TITLE
Fix: 'NodeTerminalHandler' podName length exceeding 63 characters error

### DIFF
--- a/pkg/handlers/node_terminal_handler.go
+++ b/pkg/handlers/node_terminal_handler.go
@@ -91,7 +91,14 @@ func (h *NodeTerminalHandler) HandleNodeTerminalWebSocket(c *gin.Context) {
 }
 
 func (h *NodeTerminalHandler) createNodeAgent(ctx context.Context, cs *cluster.ClientSet, nodeName string) (string, error) {
-	podName := fmt.Sprintf("%s-%s-%s", common.NodeTerminalPodName, nodeName, utils.RandomString(5))
+	
+
+	truncateNodeName := nodeName
+	if len(nodeName)+len(common.NodeTerminalPodName)+5 > 63 {
+		maxLength := 63 - len(common.NodeTerminalPodName) - 5
+		truncateNodeName = nodeName[:maxLength]
+	}
+	podName := fmt.Sprintf("%s-%s-%s", common.NodeTerminalPodName, truncateNodeName, utils.RandomString(5))
 
 	// Define the kite node agent pod spec
 	pod := &corev1.Pod{


### PR DESCRIPTION
Last time I didn't operate correctly. Resubmitting